### PR TITLE
Fix translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bulgarian, Dutch, French, Italian, Portuguese, Romanian, Spanish and Thai translations.
+
 ## [0.16.1] - 2022-09-27
 
 ### Added

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -1,4 +1,6 @@
 {
+  "admin/section.name": "Списък с подаръци",
+  "admin/subsection.name": "Управление на списък",
   "admin/interface.name": "Управление на приложение за списъци с подаръци",
   "admin/interface.title.user": "Всички собственици",
   "admin/interface.columns.title": "Заглавие",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,4 +1,6 @@
 {
+  "admin/section.name": "Liste de cadeau",
+  "admin/subsection.name": "Gestion des listes",
   "admin/interface.name": "Gestion de l'appli pour la liste des cadeaux",
   "admin/interface.title.user": "Tous les propriétaires",
   "admin/interface.columns.title": "Titre",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,5 +1,7 @@
 {
-  "admin/interface.name": "Gestione app \"Liste regali\"",
+  "admin/section.name": "Liste regali",
+  "admin/subsection.name": "Gestione delle liste",
+  "admin/interface.name": "Gestione dell'app \"Liste regali\"",
   "admin/interface.title.user": "Tutti i proprietari",
   "admin/interface.columns.title": "Titolo",
   "admin/interface.columns.user": "Utente",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,4 +1,6 @@
 {
+  "admin/section.name": "선물 목록",
+  "admin/subsection.name": "목록 관리",
   "admin/interface.name": "선물 목록 앱 관리",
   "admin/interface.title.user": "모든 소유자",
   "admin/interface.columns.title": "제목",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,4 +1,6 @@
 {
+  "admin/section.name": "Cadeaulijst",
+  "admin/subsection.name": "Lijstbeheer",
   "admin/interface.name": "Cadeaulijst app-beheer",
   "admin/interface.title.user": "Alle eigenaren",
   "admin/interface.columns.title": "Titel",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,7 @@
 {
   "admin/section.name": "Lista de presentes",
   "admin/subsection.name": "Gerenciamento de listas",
+  "admin/interface.name": "Gerenciamento do app Lista de presentes",
   "admin/interface.title.user": "Todos os proprietários",
   "admin/interface.columns.title": "Título",
   "admin/interface.columns.user": "Usuário",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,4 +1,6 @@
 {
+  "admin/section.name": "Listă de cadouri",
+  "admin/subsection.name": "Gestionare liste",
   "admin/interface.name": "Gestionare Gift List App (aplicație listă de cadouri)",
   "admin/interface.title.user": "Toți proprietarii",
   "admin/interface.columns.title": "Titlu",

--- a/messages/th.json
+++ b/messages/th.json
@@ -1,4 +1,6 @@
 {
+  "admin/section.name": "รายการของกำนัล",
+  "admin/subsection.name": "การบริหารจัดการรายการ",
   "admin/interface.name": "การบริหารจัดการแอปรายการของกำนัล",
   "admin/interface.title.user": "เจ้าของทั้งหมด",
   "admin/interface.columns.title": "คำเรียก",


### PR DESCRIPTION
Fix Bulgarian, Dutch, French, Italian, Portuguese, Romanian, Spanish and Thai translations. Tracked in task [LOC-9314](https://vtex-dev.atlassian.net/browse/LOC-9314).